### PR TITLE
Container airwaybill travel

### DIFF
--- a/backend/config/validator/validation.yaml
+++ b/backend/config/validator/validation.yaml
@@ -128,8 +128,6 @@ App\Request\TravelUpdateRequest:
       - NotBlank: ~
     shipperID:
       - NotBlank: ~
-    status:
-      - NotBlank: ~
 
 App\Request\WarehouseCreateRequest:
   properties:
@@ -259,6 +257,13 @@ App\Request\AirwaybillUpdateRequest:
       - NotBlank: ~
     airwaybillNumber:
       - NotBlank: ~
+    updatedBy:
+      - NotBlank: ~
+
+App\Request\AirwaybillStatusUpdateRequest:
+  properties:
+    id:
+      - NotBlank: ~
     status:
       - NotBlank: ~
     updatedBy:
@@ -280,6 +285,13 @@ App\Request\ContainerUpdateRequest:
     specificationID:
       - NotBlank: ~
     containerNumber:
+      - NotBlank: ~
+    updatedBy:
+      - NotBlank: ~
+
+App\Request\ContainerStatusUpdateRequest:
+  properties:
+    id:
       - NotBlank: ~
     status:
       - NotBlank: ~

--- a/backend/src/Controller/AirwaybillController.php
+++ b/backend/src/Controller/AirwaybillController.php
@@ -5,6 +5,7 @@ namespace App\Controller;
 use App\AutoMapping;
 use App\Request\AirwaybillCreateRequest;
 use App\Request\AirwaybillFilterRequest;
+use App\Request\AirwaybillStatusUpdateRequest;
 use App\Request\AirwaybillUpdateRequest;
 use App\Service\AirwaybillService;
 use Nelmio\ApiDocBundle\Annotation\Security;
@@ -158,6 +159,75 @@ class AirwaybillController extends BaseController
         }
 
         $result = $this->airwaybillService->update($request);
+
+        return $this->response($result, self::UPDATE);
+    }
+
+    /**
+     * @Route("airwaybillstatus", name="updateStatusOfAirwaybill", methods={"PUT"})
+     * @param Request $request
+     * @return JsonResponse
+     *
+     * @OA\Tag(name="Airwaybill")
+     *
+     * @OA\Parameter(
+     *      name="token",
+     *      in="header",
+     *      description="token to be passed as a header",
+     *      required=true
+     * )
+     *
+     * @OA\RequestBody(
+     *      description="Update a specific airwaybill status",
+     *      @OA\JsonContent(
+     *          @OA\Property(type="integer", property="id"),
+     *          @OA\Property(type="string", property="status")
+     *      )
+     * )
+     *
+     * @OA\Response(
+     *      response=200,
+     *      description="Returns the info of the airwaybill",
+     *      @OA\JsonContent(
+     *          @OA\Property(type="string", property="status_code"),
+     *          @OA\Property(type="string", property="msg"),
+     *          @OA\Property(type="object", property="Data",
+     *                  @OA\Property(type="integer", property="id"),
+     *                  @OA\Property(type="integer", property="specificationID"),
+     *                  @OA\Property(type="string", property="airwaybillNumber"),
+     *                  @OA\Property(type="string", property="status"),
+     *                  @OA\Property(type="object", property="createdAt"),
+     *                  @OA\Property(type="object", property="updatedAt"),
+     *                  @OA\Property(type="string", property="createdByUser"),
+     *                  @OA\Property(type="string", property="createdByUserImage"),
+     *                  @OA\Property(type="string", property="updatedByUser"),
+     *                  @OA\Property(type="string", property="updatedByUserImage"),
+     *                  @OA\Property(type="string", property="consigneeName"),
+     *                  @OA\Property(type="string", property="subcontractName"),
+     *          )
+     *      )
+     * )
+     *
+     * @Security(name="Bearer")
+     */
+    public function updateStatus(Request $request)
+    {
+        $data = json_decode($request->getContent(), true);
+
+        $request = $this->autoMapping->map(stdClass::class, AirwaybillStatusUpdateRequest::class, (object)$data);
+
+        $request->setUpdatedBy($this->getUserId());
+
+        $violations = $this->validator->validate($request);
+
+        if (\count($violations) > 0)
+        {
+            $violationsString = (string) $violations;
+
+            return new JsonResponse($violationsString, Response::HTTP_OK);
+        }
+
+        $result = $this->airwaybillService->updateStatus($request);
 
         return $this->response($result, self::UPDATE);
     }

--- a/backend/src/Controller/AirwaybillFinanceController.php
+++ b/backend/src/Controller/AirwaybillFinanceController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Controller;
+
+use App\AutoMapping;
+use App\Request\AirwaybillFinanceCreateRequest;
+use App\Service\AirwaybillFinanceService;
+use Nelmio\ApiDocBundle\Annotation\Security;
+use OpenApi\Annotations as OA;
+use stdClass;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class AirwaybillFinanceController extends BaseController
+{
+    private $autoMapping;
+    private $validator;
+    private $airwaybillFinanceService;
+
+    public function __construct(SerializerInterface $serializer, AutoMapping $autoMapping, ValidatorInterface $validator, AirwaybillFinanceService $airwaybillFinanceService)
+    {
+        parent::__construct($serializer);
+
+        $this->autoMapping = $autoMapping;
+        $this->validator = $validator;
+        $this->airwaybillFinanceService = $airwaybillFinanceService;
+    }
+
+    /**
+     * @Route("airwaybillfinance", name="createAirwaybillFinance", methods={"POST"})
+     * @param Request $request
+     * @return JsonResponse
+     *
+     * @OA\Tag(name="Airwaybill Finance")
+     *
+     * @OA\RequestBody(
+     *      description="Create new airwaybill finance",
+     *      @OA\JsonContent(
+     *          @OA\Property(type="integer", property="airwaybillID"),
+     *          @OA\Property(type="string", property="stageDescription"),
+     *          @OA\Property(type="number", property="stageCost"),
+     *          @OA\Property(type="string", property="status"),
+     *          @OA\Property(type="string", property="currency")
+     *      )
+     * )
+     *
+     * @OA\Response(
+     *      response=200,
+     *      description="Returns the creation date of the new airwaybill finance",
+     *      @OA\JsonContent(
+     *          @OA\Property(type="string", property="status_code"),
+     *          @OA\Property(type="string", property="msg"),
+     *          @OA\Property(type="object", property="Data",
+     *                  @OA\Property(type="object", property="createdAt")
+     *          )
+     *      )
+     * )
+     *
+     * @Security(name="Bearer")
+     */
+    public function create(Request $request)
+    {
+        $data = json_decode($request->getContent(), true);
+
+        $request = $this->autoMapping->map(stdClass::class, AirwaybillFinanceCreateRequest::class, (object)$data);
+
+        $request->setCreatedBy($this->getUserId());
+
+        $violations = $this->validator->validate($request);
+
+        if (\count($violations) > 0)
+        {
+            $violationsString = (string) $violations;
+
+            return new JsonResponse($violationsString, Response::HTTP_OK);
+        }
+
+        $result = $this->airwaybillFinanceService->create($request);
+
+        return $this->response($result, self::CREATE);
+    }
+
+}

--- a/backend/src/Controller/ContainerController.php
+++ b/backend/src/Controller/ContainerController.php
@@ -5,6 +5,7 @@ namespace App\Controller;
 use App\AutoMapping;
 use App\Request\ContainerCreateRequest;
 use App\Request\ContainerFilterRequest;
+use App\Request\ContainerStatusUpdateRequest;
 use App\Request\ContainerUpdateRequest;
 use App\Service\ContainerService;
 use Nelmio\ApiDocBundle\Annotation\Security;
@@ -157,6 +158,73 @@ class ContainerController extends BaseController
         }
 
         $result = $this->containerService->update($request);
+
+        return $this->response($result, self::UPDATE);
+    }
+
+    /**
+     * @Route("containerstatus", name="updateStatusOfContainer", methods={"PUT"})
+     * @param Request $request
+     * @return JsonResponse
+     *
+     * @OA\Tag(name="Container")
+     *
+     * @OA\Parameter(
+     *      name="token",
+     *      in="header",
+     *      description="token to be passed as a header",
+     *      required=true
+     * )
+     *
+     * @OA\RequestBody(
+     *      description="Update a specific container status",
+     *      @OA\JsonContent(
+     *          @OA\Property(type="integer", property="id"),
+     *          @OA\Property(type="string", property="status")
+     *      )
+     * )
+     *
+     * @OA\Response(
+     *      response=200,
+     *      description="Returns the info of the container",
+     *      @OA\JsonContent(
+     *          @OA\Property(type="string", property="status_code"),
+     *          @OA\Property(type="string", property="msg"),
+     *          @OA\Property(type="object", property="Data",
+     *                  @OA\Property(type="integer", property="id"),
+     *                  @OA\Property(type="integer", property="specificationID"),
+     *                  @OA\Property(type="string", property="containerNumber"),
+     *                  @OA\Property(type="string", property="status"),
+     *                  @OA\Property(type="object", property="createdAt"),
+     *                  @OA\Property(type="object", property="updatedAt"),
+     *                  @OA\Property(type="string", property="createdByUser"),
+     *                  @OA\Property(type="string", property="createdByUserImage"),
+     *                  @OA\Property(type="string", property="updatedByUser"),
+     *                  @OA\Property(type="string", property="updatedByUserImage")
+     *          )
+     *      )
+     * )
+     *
+     * @Security(name="Bearer")
+     */
+    public function updateStatus(Request $request)
+    {
+        $data = json_decode($request->getContent(), true);
+
+        $request = $this->autoMapping->map(stdClass::class, ContainerStatusUpdateRequest::class, (object)$data);
+
+        $request->setUpdatedBy($this->getUserId());
+
+        $violations = $this->validator->validate($request);
+
+        if (\count($violations) > 0)
+        {
+            $violationsString = (string) $violations;
+
+            return new JsonResponse($violationsString, Response::HTTP_OK);
+        }
+
+        $result = $this->containerService->updateStatus($request);
 
         return $this->response($result, self::UPDATE);
     }

--- a/backend/src/Controller/ContainerFinanceController.php
+++ b/backend/src/Controller/ContainerFinanceController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Controller;
+
+use App\AutoMapping;
+use App\Request\ContainerFinanceCreateRequest;
+use App\Service\ContainerFinanceService;
+use Nelmio\ApiDocBundle\Annotation\Security;
+use OpenApi\Annotations as OA;
+use stdClass;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class ContainerFinanceController extends BaseController
+{
+    private $autoMapping;
+    private $validator;
+    private $containerFinanceService;
+
+    public function __construct(SerializerInterface $serializer, AutoMapping $autoMapping, ValidatorInterface $validator, ContainerFinanceService $containerFinanceService)
+    {
+        parent::__construct($serializer);
+
+        $this->autoMapping = $autoMapping;
+        $this->validator = $validator;
+        $this->containerFinanceService = $containerFinanceService;
+    }
+
+    /**
+     * @Route("containerfinance", name="createContainerFinance", methods={"POST"})
+     * @param Request $request
+     * @return JsonResponse
+     *
+     * @OA\Tag(name="Container Finance")
+     *
+     * @OA\RequestBody(
+     *      description="Create new container finance",
+     *      @OA\JsonContent(
+     *          @OA\Property(type="integer", property="containerID"),
+     *          @OA\Property(type="string", property="stageDescription"),
+     *          @OA\Property(type="number", property="stageCost"),
+     *          @OA\Property(type="string", property="status"),
+     *          @OA\Property(type="string", property="currency")
+     *      )
+     * )
+     *
+     * @OA\Response(
+     *      response=200,
+     *      description="Returns the creation date of the new container finance",
+     *      @OA\JsonContent(
+     *          @OA\Property(type="string", property="status_code"),
+     *          @OA\Property(type="string", property="msg"),
+     *          @OA\Property(type="object", property="Data",
+     *                  @OA\Property(type="object", property="createdAt")
+     *          )
+     *      )
+     * )
+     *
+     * @Security(name="Bearer")
+     */
+    public function create(Request $request)
+    {
+        $data = json_decode($request->getContent(), true);
+
+        $request = $this->autoMapping->map(stdClass::class, ContainerFinanceCreateRequest::class, (object)$data);
+
+        $request->setCreatedBy($this->getUserId());
+
+        $violations = $this->validator->validate($request);
+
+        if (\count($violations) > 0)
+        {
+            $violationsString = (string) $violations;
+
+            return new JsonResponse($violationsString, Response::HTTP_OK);
+        }
+
+        $result = $this->containerFinanceService->create($request);
+
+        return $this->response($result, self::CREATE);
+    }
+
+}

--- a/backend/src/Controller/ShipmentFinanceController.php
+++ b/backend/src/Controller/ShipmentFinanceController.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Controller;
+
+use App\AutoMapping;
+use App\Request\ShipmentFinanceCreateRequest;
+use App\Service\ShipmentFinanceService;
+use Nelmio\ApiDocBundle\Annotation\Security;
+use OpenApi\Annotations as OA;
+use stdClass;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class ShipmentFinanceController extends BaseController
+{
+    private $autoMapping;
+    private $validator;
+    private $shipmentFinanceService;
+
+    public function __construct(SerializerInterface $serializer, AutoMapping $autoMapping, ValidatorInterface $validator, ShipmentFinanceService $shipmentFinanceService)
+    {
+        parent::__construct($serializer);
+
+        $this->autoMapping = $autoMapping;
+        $this->validator = $validator;
+        $this->shipmentFinanceService = $shipmentFinanceService;
+    }
+
+    /**
+     * @Route("shipmentfinance", name="createShipmentFinance", methods={"POST"})
+     * @param Request $request
+     * @return JsonResponse
+     *
+     * @OA\Tag(name="Shipment Finance")
+     *
+     * @OA\RequestBody(
+     *      description="Create new shipment finance",
+     *      @OA\JsonContent(
+     *          @OA\Property(type="integer", property="shipmentID"),
+     *          @OA\Property(type="string", property="trackNumber"),
+     *          @OA\Property(type="string", property="stageDescription"),
+     *          @OA\Property(type="number", property="stageCost"),
+     *          @OA\Property(type="string", property="shipmentStatus"),
+     *          @OA\Property(type="string", property="currency")
+     *      )
+     * )
+     *
+     * @OA\Response(
+     *      response=200,
+     *      description="Returns the creation date of the new shipment finance",
+     *      @OA\JsonContent(
+     *          @OA\Property(type="string", property="status_code"),
+     *          @OA\Property(type="string", property="msg"),
+     *          @OA\Property(type="object", property="Data",
+     *                  @OA\Property(type="object", property="createdAt")
+     *          )
+     *      )
+     * )
+     *
+     * @Security(name="Bearer")
+     */
+    public function create(Request $request)
+    {
+        $data = json_decode($request->getContent(), true);
+
+        $request = $this->autoMapping->map(stdClass::class, ShipmentFinanceCreateRequest::class, (object)$data);
+
+        $request->setCreatedBy($this->getUserId());
+
+        $violations = $this->validator->validate($request);
+
+        if (\count($violations) > 0)
+        {
+            $violationsString = (string) $violations;
+
+            return new JsonResponse($violationsString, Response::HTTP_OK);
+        }
+
+        $result = $this->shipmentFinanceService->create($request);
+
+        return $this->response($result, self::CREATE);
+    }
+
+    /**
+     * @Route("shipmentfinance/{shipmentID}/{trackNumber}", name="getShipmentFinanceByShipmentIdAndTrackNumber", methods={"GET"})
+     * @return JsonResponse
+     * 
+     * @OA\Tag(name="Shipment Finance")
+     * 
+     * @OA\Parameter(
+     *      name="shipmentID",
+     *      in="path",
+     *      required="true",
+     *      description="the id of the shipment order"
+     * )
+     * 
+     * @OA\Parameter(
+     *      name="trackNumber",
+     *      in="path",
+     *      required="true",
+     *      description="the track number of the shipment"
+     * )
+     * 
+     * @OA\Response(
+     *      response=200,
+     *      description="Returns the info of the shipment finances",
+     *      @OA\JsonContent(
+     *          @OA\Property(type="string", property="status_code"),
+     *          @OA\Property(type="string", property="msg"),
+     *          @OA\Property(type="array", property="Data",
+     *              @OA\Items(
+     *                  @OA\Property(type="integer", property="shipmentID"),
+     *                  @OA\Property(type="string", property="trackNumber"),
+     *                  @OA\Property(type="string", property="shipmentStatus"),
+     *                  @OA\Property(type="number", property="stageCost"),
+     *                  @OA\Property(type="string", property="stageDescription"),
+     *                  @OA\Property(type="string", property="currency"),
+     *                  @OA\Property(type="object", property="createdAt"),
+     *                  @OA\Property(type="object", property="updatedAt"),
+     *                  @OA\Property(type="string", property="createdByUser"),
+     *                  @OA\Property(type="string", property="createdByUserImage"),
+     *                  @OA\Property(type="string", property="updatedByUser"),
+     *                  @OA\Property(type="string", property="updatedByUserImage")
+     *              )
+     *          )
+     *      )
+     * )
+     * 
+     */
+    public function getAllCostsByShipmentIdAndTrackNumber($shipmentID, $trackNumber)
+    {
+        $result = $this->shipmentFinanceService->getAllCostsByShipmentIdAndTrackNumber($shipmentID, $trackNumber);
+        
+        return $this->response($result, self::FETCH);
+    }
+
+}

--- a/backend/src/Controller/TravelController.php
+++ b/backend/src/Controller/TravelController.php
@@ -101,7 +101,6 @@ class TravelController extends BaseController
      *      description="Update a travel",
      *      @OA\JsonContent(
      *          @OA\Property(type="integer", property="id"),
-     *          @OA\Property(type="string", property="status"),
      *          @OA\Property(type="string", property="type"),
      *          @OA\Property(type="string", property="launchCountry"),
      *          @OA\Property(type="string", property="destinationCountry"),

--- a/backend/src/Controller/WarehouseController.php
+++ b/backend/src/Controller/WarehouseController.php
@@ -48,7 +48,8 @@ class WarehouseController extends BaseController
      *          @OA\Property(type="string", property="location"),
      *          @OA\Property(type="number", property="rentingFee"),
      *          @OA\Property(type="integer", property="proxyID"),
-     *          @OA\Property(type="integer", property="subcontractID")
+     *          @OA\Property(type="integer", property="subcontractID"),
+     *          @OA\Property(type="string", property="type")
      *      )
      * )
      * 
@@ -105,7 +106,8 @@ class WarehouseController extends BaseController
      *          @OA\Property(type="string", property="location"),
      *          @OA\Property(type="number", property="rentingFee"),
      *          @OA\Property(type="integer", property="proxyID"),
-     *          @OA\Property(type="integer", property="subcontractID")
+     *          @OA\Property(type="integer", property="subcontractID"),
+     *          @OA\Property(type="string", property="type")
      *      )
      * )
      * 
@@ -178,6 +180,7 @@ class WarehouseController extends BaseController
      *                  @OA\Property(type="string", property="countryName"),
      *                  @OA\Property(type="string", property="city"),
      *                  @OA\Property(type="string", property="location"),
+     *                  @OA\Property(type="string", property="type"),
      *                  @OA\Property(type="number", property="rentingFee"),
      *                  @OA\Property(type="string", property="proxyName"),
      *                  @OA\Property(type="object", property="createdAt"),
@@ -220,6 +223,7 @@ class WarehouseController extends BaseController
      *                  @OA\Property(type="string", property="countryName"),
      *                  @OA\Property(type="string", property="city"),
      *                  @OA\Property(type="string", property="location"),
+     *                  @OA\Property(type="string", property="type"),
      *                  @OA\Property(type="number", property="rentingFee"),
      *                  @OA\Property(type="string", property="proxyName"),
      *                  @OA\Property(type="object", property="createdAt"),

--- a/backend/src/Entity/AirwaybillFinanceEntity.php
+++ b/backend/src/Entity/AirwaybillFinanceEntity.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\AirwaybillFinanceEntityRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ORM\Entity(repositoryClass=AirwaybillFinanceEntityRepository::class)
+ */
+class AirwaybillFinanceEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="integer")
+     */
+    private $airwaybillID;
+
+    /**
+     * @ORM\Column(type="string", length=50)
+     */
+    private $status;
+
+    /**
+     * @ORM\Column(type="text", nullable=true)
+     */
+    private $stageDescription;
+
+    /**
+     * @ORM\Column(type="float")
+     */
+    private $stageCost;
+
+    /**
+     * @ORM\Column(type="string", length=50)
+     */
+    private $currency;
+
+    /**
+     * @Gedmo\Timestampable(on="create")
+     * @ORM\Column(type="datetime")
+     */
+    private $createdAt;
+
+    /**
+     * @Gedmo\Timestampable(on="update")
+     * @ORM\Column(type="datetime")
+     */
+    private $updatedAt;
+
+    /**
+     * @ORM\Column(type="integer")
+     */
+    private $createdBy;
+
+    /**
+     * @ORM\Column(type="integer", nullable=true)
+     */
+    private $updatedBy;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getAirwaybillID(): ?int
+    {
+        return $this->airwaybillID;
+    }
+
+    public function setAirwaybillID(int $airwaybillID): self
+    {
+        $this->airwaybillID = $airwaybillID;
+
+        return $this;
+    }
+
+    public function getStatus(): ?string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function getStageDescription(): ?string
+    {
+        return $this->stageDescription;
+    }
+
+    public function setStageDescription(?string $stageDescription): self
+    {
+        $this->stageDescription = $stageDescription;
+
+        return $this;
+    }
+
+    public function getStageCost(): ?float
+    {
+        return $this->stageCost;
+    }
+
+    public function setStageCost(float $stageCost): self
+    {
+        $this->stageCost = $stageCost;
+
+        return $this;
+    }
+
+    public function getCurrency(): ?string
+    {
+        return $this->currency;
+    }
+
+    public function setCurrency(string $currency): self
+    {
+        $this->currency = $currency;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?\DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeInterface $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?\DateTimeInterface
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(\DateTimeInterface $updatedAt): self
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+
+    public function getCreatedBy(): ?int
+    {
+        return $this->createdBy;
+    }
+
+    public function setCreatedBy(int $createdBy): self
+    {
+        $this->createdBy = $createdBy;
+
+        return $this;
+    }
+
+    public function getUpdatedBy(): ?int
+    {
+        return $this->updatedBy;
+    }
+
+    public function setUpdatedBy(?int $updatedBy): self
+    {
+        $this->updatedBy = $updatedBy;
+
+        return $this;
+    }
+}

--- a/backend/src/Entity/ContainerFinanceEntity.php
+++ b/backend/src/Entity/ContainerFinanceEntity.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\ContainerFinanceEntityRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ORM\Entity(repositoryClass=ContainerFinanceEntityRepository::class)
+ */
+class ContainerFinanceEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="integer")
+     */
+    private $containerID;
+
+    /**
+     * @ORM\Column(type="string", length=50)
+     */
+    private $status;
+
+    /**
+     * @ORM\Column(type="text", nullable=true)
+     */
+    private $stageDescription;
+
+    /**
+     * @ORM\Column(type="float")
+     */
+    private $stageCost;
+
+    /**
+     * @ORM\Column(type="string", length=50)
+     */
+    private $currency;
+
+    /**
+     * @Gedmo\Timestampable(on="create")
+     * @ORM\Column(type="datetime")
+     */
+    private $createdAt;
+
+    /**
+     * @Gedmo\Timestampable(on="update")
+     * @ORM\Column(type="datetime")
+     */
+    private $updatedAt;
+
+    /**
+     * @ORM\Column(type="integer")
+     */
+    private $createdBy;
+
+    /**
+     * @ORM\Column(type="integer", nullable=true)
+     */
+    private $updatedBy;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getContainerID(): ?int
+    {
+        return $this->containerID;
+    }
+
+    public function setContainerID(int $containerID): self
+    {
+        $this->containerID = $containerID;
+
+        return $this;
+    }
+
+    public function getStatus(): ?string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function getStageDescription(): ?string
+    {
+        return $this->stageDescription;
+    }
+
+    public function setStageDescription(?string $stageDescription): self
+    {
+        $this->stageDescription = $stageDescription;
+
+        return $this;
+    }
+
+    public function getStageCost(): ?float
+    {
+        return $this->stageCost;
+    }
+
+    public function setStageCost(float $stageCost): self
+    {
+        $this->stageCost = $stageCost;
+
+        return $this;
+    }
+
+    public function getCurrency(): ?string
+    {
+        return $this->currency;
+    }
+
+    public function setCurrency(string $currency): self
+    {
+        $this->currency = $currency;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?\DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeInterface $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?\DateTimeInterface
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(\DateTimeInterface $updatedAt): self
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+
+    public function getCreatedBy(): ?int
+    {
+        return $this->createdBy;
+    }
+
+    public function setCreatedBy(int $createdBy): self
+    {
+        $this->createdBy = $createdBy;
+
+        return $this;
+    }
+
+    public function getUpdatedBy(): ?int
+    {
+        return $this->updatedBy;
+    }
+
+    public function setUpdatedBy(?int $updatedBy): self
+    {
+        $this->updatedBy = $updatedBy;
+
+        return $this;
+    }
+}

--- a/backend/src/Entity/ShipmentFinanceEntity.php
+++ b/backend/src/Entity/ShipmentFinanceEntity.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\ShipmentFinanceEntityRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ORM\Entity(repositoryClass=ShipmentFinanceEntityRepository::class)
+ */
+class ShipmentFinanceEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="integer")
+     */
+    private $shipmentID;
+
+    /**
+     * @ORM\Column(type="string", length=50)
+     */
+    private $trackNumber;
+
+    /**
+     * @ORM\Column(type="text", nullable=true)
+     */
+    private $stageDescription;
+
+    /**
+     * @ORM\Column(type="float")
+     */
+    private $stageCost;
+
+    /**
+     * @ORM\Column(type="string", length=50)
+     */
+    private $shipmentStatus;
+
+    /**
+     * @ORM\Column(type="string", length=50)
+     */
+    private $currency;
+
+    /**
+     * @Gedmo\Timestampable(on="create")
+     * @ORM\Column(type="datetime")
+     */
+    private $createdAt;
+
+    /**
+     * @Gedmo\Timestampable(on="update")
+     * @ORM\Column(type="datetime")
+     */
+    private $updatedAt;
+
+    /**
+     * @ORM\Column(type="integer")
+     */
+    private $createdBy;
+
+    /**
+     * @ORM\Column(type="integer", nullable=true)
+     */
+    private $updatedBy;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getShipmentID(): ?int
+    {
+        return $this->shipmentID;
+    }
+
+    public function setShipmentID(int $shipmentID): self
+    {
+        $this->shipmentID = $shipmentID;
+
+        return $this;
+    }
+
+    public function getTrackNumber(): ?string
+    {
+        return $this->trackNumber;
+    }
+
+    public function setTrackNumber(string $trackNumber): self
+    {
+        $this->trackNumber = $trackNumber;
+
+        return $this;
+    }
+
+    public function getStageDescription(): ?string
+    {
+        return $this->stageDescription;
+    }
+
+    public function setStageDescription(?string $stageDescription): self
+    {
+        $this->stageDescription = $stageDescription;
+
+        return $this;
+    }
+
+    public function getStageCost(): ?float
+    {
+        return $this->stageCost;
+    }
+
+    public function setStageCost(float $stageCost): self
+    {
+        $this->stageCost = $stageCost;
+
+        return $this;
+    }
+
+    public function getShipmentStatus(): ?string
+    {
+        return $this->shipmentStatus;
+    }
+
+    public function setShipmentStatus(string $shipmentStatus): self
+    {
+        $this->shipmentStatus = $shipmentStatus;
+
+        return $this;
+    }
+
+    public function getCurrency(): ?string
+    {
+        return $this->currency;
+    }
+
+    public function setCurrency(?string $currency): self
+    {
+        $this->currency = $currency;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?\DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeInterface $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?\DateTimeInterface
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(\DateTimeInterface $updatedAt): self
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+
+    public function getCreatedBy(): ?int
+    {
+        return $this->createdBy;
+    }
+
+    public function setCreatedBy(int $createdBy): self
+    {
+        $this->createdBy = $createdBy;
+
+        return $this;
+    }
+
+    public function getUpdatedBy(): ?int
+    {
+        return $this->updatedBy;
+    }
+
+    public function setUpdatedBy(?int $updatedBy): self
+    {
+        $this->updatedBy = $updatedBy;
+
+        return $this;
+    }
+}

--- a/backend/src/Entity/WarehouseEntity.php
+++ b/backend/src/Entity/WarehouseEntity.php
@@ -75,6 +75,11 @@ class WarehouseEntity
      */
     private $subcontractID;
 
+    /**
+     * @ORM\Column(type="string", length=50)
+     */
+    private $type;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -208,6 +213,18 @@ class WarehouseEntity
     public function setSubcontractID(?int $subcontractID): self
     {
         $this->subcontractID = $subcontractID;
+
+        return $this;
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    public function setType(string $type): self
+    {
+        $this->type = $type;
 
         return $this;
     }

--- a/backend/src/Manager/AirwaybillFinanceManager.php
+++ b/backend/src/Manager/AirwaybillFinanceManager.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Manager;
+
+use App\AutoMapping;
+use App\Entity\AirwaybillFinanceEntity;
+use App\Repository\AirwaybillFinanceEntityRepository;
+use App\Request\AirwaybillFinanceCreateRequest;
+use Doctrine\ORM\EntityManagerInterface;
+
+class AirwaybillFinanceManager
+{
+    private $autoMapping;
+    private $entityManager;
+    private $airwaybillFinanceEntityRepository;
+
+    public function __construct(AutoMapping $autoMapping, EntityManagerInterface $entityManager, AirwaybillFinanceEntityRepository $airwaybillFinanceEntityRepository)
+    {
+        $this->autoMapping = $autoMapping;
+        $this->entityManager = $entityManager;
+        $this->airwaybillFinanceEntityRepository = $airwaybillFinanceEntityRepository;
+    }
+
+    public function create(AirwaybillFinanceCreateRequest $request)
+    {
+        $airwaybillFinanceEntity = $this->autoMapping->map(AirwaybillFinanceCreateRequest::class, AirwaybillFinanceEntity::class, $request);
+
+        $this->entityManager->persist($airwaybillFinanceEntity);
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        return $airwaybillFinanceEntity;
+    }
+
+}

--- a/backend/src/Manager/AirwaybillManager.php
+++ b/backend/src/Manager/AirwaybillManager.php
@@ -8,6 +8,7 @@ use App\Entity\AirwaybillEntity;
 use App\Repository\AirwaybillEntityRepository;
 use App\Request\AirwaybillCreateRequest;
 use App\Request\AirwaybillFilterRequest;
+use App\Request\AirwaybillStatusUpdateRequest;
 use App\Request\AirwaybillUpdateRequest;
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -43,12 +44,30 @@ class AirwaybillManager
 
         if(!$airwaybillEntity)
         {
-            return  $airwaybillEntity;
+            return $airwaybillEntity;
         }
         else
         {
-            $airwaybillEntity = $this->autoMapping->mapToObject(AirwaybillUpdateRequest::class, AirwaybillEntity::class,
-                $request, $airwaybillEntity);
+            $airwaybillEntity = $this->autoMapping->mapToObject(AirwaybillUpdateRequest::class, AirwaybillEntity::class, $request, $airwaybillEntity);
+
+            $this->entityManager->flush();
+            $this->entityManager->clear();
+
+            return $airwaybillEntity;
+        }
+    }
+
+    public function updateStatus(AirwaybillStatusUpdateRequest $request)
+    {
+        $airwaybillEntity = $this->airwaybillEntityRepository->find($request->getId());
+
+        if(!$airwaybillEntity)
+        {
+            return $airwaybillEntity;
+        }
+        else
+        {
+            $airwaybillEntity = $this->autoMapping->mapToObject(AirwaybillStatusUpdateRequest::class, AirwaybillEntity::class, $request, $airwaybillEntity);
 
             $this->entityManager->flush();
             $this->entityManager->clear();

--- a/backend/src/Manager/ContainerFinanceManager.php
+++ b/backend/src/Manager/ContainerFinanceManager.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Manager;
+
+use App\AutoMapping;
+use App\Entity\ContainerFinanceEntity;
+use App\Repository\ContainerFinanceEntityRepository;
+use App\Request\ContainerFinanceCreateRequest;
+use Doctrine\ORM\EntityManagerInterface;
+
+class ContainerFinanceManager
+{
+    private $autoMapping;
+    private $entityManager;
+    private $containerFinanceEntityRepository;
+    private $trackManager;
+
+    public function __construct(AutoMapping $autoMapping, EntityManagerInterface $entityManager, ContainerFinanceEntityRepository $containerFinanceEntityRepository,
+     TrackManager $trackManager)
+    {
+        $this->autoMapping = $autoMapping;
+        $this->entityManager = $entityManager;
+        $this->containerFinanceEntityRepository = $containerFinanceEntityRepository;
+        $this->trackManager = $trackManager;
+    }
+
+    public function create(ContainerFinanceCreateRequest $request)
+    {
+        $containerFinanceEntity = $this->autoMapping->map(ContainerFinanceCreateRequest::class, ContainerFinanceEntity::class, $request);
+
+        $this->entityManager->persist($containerFinanceEntity);
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        return $containerFinanceEntity;
+    }
+
+}

--- a/backend/src/Manager/ContainerManager.php
+++ b/backend/src/Manager/ContainerManager.php
@@ -8,6 +8,7 @@ use App\Entity\ContainerEntity;
 use App\Repository\ContainerEntityRepository;
 use App\Request\ContainerCreateRequest;
 use App\Request\ContainerFilterRequest;
+use App\Request\ContainerStatusUpdateRequest;
 use App\Request\ContainerUpdateRequest;
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -43,12 +44,30 @@ class ContainerManager
 
         if(!$containerEntity)
         {
-            return  $containerEntity;
+            return $containerEntity;
         }
         else
         {
-            $containerEntity = $this->autoMapping->mapToObject(ContainerUpdateRequest::class, ContainerEntity::class,
-                $request, $containerEntity);
+            $containerEntity = $this->autoMapping->mapToObject(ContainerUpdateRequest::class, ContainerEntity::class, $request, $containerEntity);
+
+            $this->entityManager->flush();
+            $this->entityManager->clear();
+
+            return $containerEntity;
+        }
+    }
+
+    public function updateStatus(ContainerStatusUpdateRequest $request)
+    {
+        $containerEntity = $this->containerEntityRepository->find($request->getId());
+
+        if(!$containerEntity)
+        {
+            return $containerEntity;
+        }
+        else
+        {
+            $containerEntity = $this->autoMapping->mapToObject(ContainerStatusUpdateRequest::class, ContainerEntity::class, $request, $containerEntity);
 
             $this->entityManager->flush();
             $this->entityManager->clear();

--- a/backend/src/Manager/ShipmentFinanceManager.php
+++ b/backend/src/Manager/ShipmentFinanceManager.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Manager;
+
+use App\AutoMapping;
+use App\Entity\ShipmentFinanceEntity;
+use App\Repository\ShipmentFinanceEntityRepository;
+use App\Request\ShipmentFinanceCreateRequest;
+use Doctrine\ORM\EntityManagerInterface;
+
+class ShipmentFinanceManager
+{
+    private $autoMapping;
+    private $entityManager;
+    private $shipmentFinanceEntityRepository;
+
+    public function __construct(AutoMapping $autoMapping, EntityManagerInterface $entityManager, ShipmentFinanceEntityRepository $shipmentFinanceEntityRepository)
+    {
+        $this->autoMapping = $autoMapping;
+        $this->entityManager = $entityManager;
+        $this->shipmentFinanceEntityRepository = $shipmentFinanceEntityRepository;
+    }
+
+    public function create(ShipmentFinanceCreateRequest $request)
+    {
+        $shipmentFinanceEntity = $this->autoMapping->map(ShipmentFinanceCreateRequest::class, ShipmentFinanceEntity::class, $request);
+
+        $this->entityManager->persist($shipmentFinanceEntity);
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        return $shipmentFinanceEntity;
+    }
+
+    public function getAllCostsByShipmentIdAndTrackNumber($shipmentID, $trackNumber)
+    {
+        return $this->shipmentFinanceEntityRepository->getAllCostsByShipmentIdAndTrackNumber($shipmentID, $trackNumber);
+    }
+
+    public function getCurrentTotalCostByShipmentIdAndTrackNumber($shipmentID, $trackNumber)
+    {
+        return $this->shipmentFinanceEntityRepository->getCurrentTotalCostByShipmentIdAndTrackNumber($shipmentID, $trackNumber);
+    }
+
+}

--- a/backend/src/Repository/AirwaybillFinanceEntityRepository.php
+++ b/backend/src/Repository/AirwaybillFinanceEntityRepository.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\AirwaybillFinanceEntity;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method AirwaybillFinanceEntity|null find($id, $lockMode = null, $lockVersion = null)
+ * @method AirwaybillFinanceEntity|null findOneBy(array $criteria, array $orderBy = null)
+ * @method AirwaybillFinanceEntity[]    findAll()
+ * @method AirwaybillFinanceEntity[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class AirwaybillFinanceEntityRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, AirwaybillFinanceEntity::class);
+    }
+
+}

--- a/backend/src/Repository/ContainerFinanceEntityRepository.php
+++ b/backend/src/Repository/ContainerFinanceEntityRepository.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\ContainerFinanceEntity;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method ContainerFinanceEntity|null find($id, $lockMode = null, $lockVersion = null)
+ * @method ContainerFinanceEntity|null findOneBy(array $criteria, array $orderBy = null)
+ * @method ContainerFinanceEntity[]    findAll()
+ * @method ContainerFinanceEntity[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class ContainerFinanceEntityRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ContainerFinanceEntity::class);
+    }
+
+}

--- a/backend/src/Repository/ShipmentFinanceEntityRepository.php
+++ b/backend/src/Repository/ShipmentFinanceEntityRepository.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\AdminProfileEntity;
+use App\Entity\ShipmentFinanceEntity;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\Query\Expr\Join;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method ShipmentFinanceEntity|null find($id, $lockMode = null, $lockVersion = null)
+ * @method ShipmentFinanceEntity|null findOneBy(array $criteria, array $orderBy = null)
+ * @method ShipmentFinanceEntity[]    findAll()
+ * @method ShipmentFinanceEntity[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class ShipmentFinanceEntityRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ShipmentFinanceEntity::class);
+    }
+
+    public function getAllCostsByShipmentIdAndTrackNumber($shipmentID, $trackNumber)
+    {
+        return $this->createQueryBuilder('shipmentFinance')
+            ->select('shipmentFinance.id', 'shipmentFinance.shipmentID', 'shipmentFinance.trackNumber', 'shipmentFinance.shipmentStatus', 'shipmentFinance.stageCost', 'shipmentFinance.stageDescription',
+            'shipmentFinance.currency', 'shipmentFinance.createdAt', 'shipmentFinance.updatedAt', 'shipmentFinance.createdBy', 'shipmentFinance.updatedBy', 'adminProfile1.userName as createdByUser', 
+            'adminProfile1.image as createdByUserImage', 'adminProfile2.userName as updatedByUser', 'adminProfile2.image as updatedByUserImage')
+
+            ->andWhere('shipmentFinance.shipmentID = :shipmentID')
+            ->setParameter('shipmentID', $shipmentID)
+
+            ->andWhere('shipmentFinance.trackNumber = :trackNumber')
+            ->setParameter('trackNumber', $trackNumber)
+
+            ->leftJoin(
+                AdminProfileEntity::class,
+                'adminProfile1',
+                Join::WITH,
+                'adminProfile1.userID = shipmentFinance.createdBy'
+            )
+
+            ->leftJoin(
+                AdminProfileEntity::class,
+                'adminProfile2',
+                Join::WITH,
+                'adminProfile2.userID = shipmentFinance.updatedBy'
+            )
+
+            ->orderBy('shipmentFinance.id', 'DESC')
+
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function getCurrentTotalCostByShipmentIdAndTrackNumber($shipmentID, $trackNumber)
+    {
+        return $this->createQueryBuilder('shipmentFinance')
+            ->select('SUM(shipmentFinance.stageCost) as currentTotalCost')
+
+            ->andWhere('shipmentFinance.shipmentID = :shipmentID')
+            ->setParameter('shipmentID', $shipmentID)
+
+            ->andWhere('shipmentFinance.trackNumber = :trackNumber')
+            ->setParameter('trackNumber', $trackNumber)
+
+            ->getQuery()
+            ->getResult();
+    }
+
+}

--- a/backend/src/Repository/WarehouseEntityRepository.php
+++ b/backend/src/Repository/WarehouseEntityRepository.php
@@ -27,7 +27,7 @@ class WarehouseEntityRepository extends ServiceEntityRepository
     public function getAllWarehouses()
     {
         return $this->createQueryBuilder('warehouse')
-            ->select('warehouse.id', 'warehouse.city', 'warehouse.countryID', 'warehouse.location', 'warehouse.proxyID', 'warehouse.rentingFee',
+            ->select('warehouse.id', 'warehouse.city', 'warehouse.countryID', 'warehouse.location', 'warehouse.type', 'warehouse.proxyID', 'warehouse.rentingFee',
              'warehouse.name', 'warehouse.createdAt', 'warehouse.updatedAt', 'warehouse.createdBy', 'warehouse.updatedBy', 'country.name as countryName',
                 'proxy.fullName as proxyName', 'adminProfile1.userName as createdByUser', 'adminProfile1.image as createdByUserImage', 'warehouse.subcontractID',
                 'adminProfile2.userName as updatedByUser', 'adminProfile2.image as updatedByUserImage', 'subcontract.fullName as subcontractName')
@@ -76,7 +76,7 @@ class WarehouseEntityRepository extends ServiceEntityRepository
     public function getWarehousesByCountryID($countryID)
     {
         return $this->createQueryBuilder('warehouse')
-            ->select('warehouse.id', 'warehouse.city', 'warehouse.countryID', 'warehouse.location', 'warehouse.proxyID', 'warehouse.rentingFee',
+            ->select('warehouse.id', 'warehouse.city', 'warehouse.countryID', 'warehouse.location', 'warehouse.type', 'warehouse.proxyID', 'warehouse.rentingFee',
                 'warehouse.name', 'warehouse.createdAt', 'warehouse.updatedAt', 'warehouse.createdBy', 'warehouse.updatedBy', 'country.name as countryName',
                 'proxy.fullName as proxyName', 'adminProfile1.userName as createdByUser', 'adminProfile1.image as createdByUserImage', 'warehouse.subcontractID',
                 'adminProfile2.userName as updatedByUser', 'adminProfile2.image as updatedByUserImage', 'subcontract.fullName as subcontractName')

--- a/backend/src/Request/AirwaybillFinanceCreateRequest.php
+++ b/backend/src/Request/AirwaybillFinanceCreateRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Request;
+
+class AirwaybillFinanceCreateRequest
+{
+    private $airwaybillID;
+
+    private $stageDescription;
+
+    private $stageCost;
+
+    private $status;
+
+    private $currency;
+
+    private $createdBy;
+
+    public function setCreatedBy($createdBy)
+    {
+        $this->createdBy = $createdBy;
+    }
+
+    public function setAirwaybillID($airwaybillID)
+    {
+        $this->airwaybillID = $airwaybillID;
+    }
+
+    public function setStatus($status)
+    {
+        $this->status = $status;
+    }
+
+}

--- a/backend/src/Request/AirwaybillStatusUpdateRequest.php
+++ b/backend/src/Request/AirwaybillStatusUpdateRequest.php
@@ -2,21 +2,11 @@
 
 namespace App\Request;
 
-class AirwaybillUpdateRequest
+class AirwaybillStatusUpdateRequest
 {
     private $id;
 
-    private $specificationID;
-
-    private $airwaybillNumber;
-
-    private $type;
-
-    private $providedBy;
-
-    private $shipperID;
-
-    private $consigneeID;
+    private $status;
 
     private $updatedBy;
 

--- a/backend/src/Request/ContainerFinanceCreateRequest.php
+++ b/backend/src/Request/ContainerFinanceCreateRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Request;
+
+class ContainerFinanceCreateRequest
+{
+    private $containerID;
+
+    private $stageDescription;
+
+    private $stageCost;
+
+    private $status;
+
+    private $currency;
+
+    private $createdBy;
+
+    public function setCreatedBy($createdBy)
+    {
+        $this->createdBy = $createdBy;
+    }
+
+    public function setContainerID($containerID)
+    {
+        $this->containerID = $containerID;
+    }
+
+    public function setStatus($status)
+    {
+        $this->status = $status;
+    }
+
+}

--- a/backend/src/Request/ContainerStatusUpdateRequest.php
+++ b/backend/src/Request/ContainerStatusUpdateRequest.php
@@ -2,21 +2,11 @@
 
 namespace App\Request;
 
-class ContainerUpdateRequest
+class ContainerStatusUpdateRequest
 {
     private $id;
 
-    private $specificationID;
-
-    private $containerNumber;
-
-    private $type;
-
-    private $providedBy;
-
-    private $shipperID;
-
-    private $consigneeID;
+    private $status;
 
     private $updatedBy;
 

--- a/backend/src/Request/ShipmentFinanceCreateRequest.php
+++ b/backend/src/Request/ShipmentFinanceCreateRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Request;
+
+class ShipmentFinanceCreateRequest
+{
+    private $shipmentID;
+
+    private $trackNumber;
+
+    private $stageDescription;
+
+    private $stageCost;
+
+    private $shipmentStatus;
+
+    private $currency;
+
+    private $createdBy;
+
+    public function setCreatedBy($createdBy)
+    {
+        $this->createdBy = $createdBy;
+    }
+
+}

--- a/backend/src/Request/TravelUpdateRequest.php
+++ b/backend/src/Request/TravelUpdateRequest.php
@@ -22,8 +22,6 @@ class TravelUpdateRequest
 
     private $updatedBy;
 
-    private $status;
-
     public function getId()
     {
         return $this->id;
@@ -32,11 +30,6 @@ class TravelUpdateRequest
     public function setUpdatedBy($updatedBy)
     {
         $this->updatedBy = $updatedBy;
-    }
-
-    public function getStatus()
-    {
-        return $this->status;
     }
 
     public function getLaunchDate()

--- a/backend/src/Request/WarehouseCreateRequest.php
+++ b/backend/src/Request/WarehouseCreateRequest.php
@@ -20,6 +20,8 @@ class WarehouseCreateRequest
 
     private $proxyID;
 
+    private $type;
+
     public function setCreatedBy($userID)
     {
         $this->createdBy = $userID;

--- a/backend/src/Request/WarehouseUpdateRequest.php
+++ b/backend/src/Request/WarehouseUpdateRequest.php
@@ -22,6 +22,8 @@ class WarehouseUpdateRequest
 
     private $proxyID;
 
+    private $type;
+
     public function getId()
     {
         return $this->id;

--- a/backend/src/Response/AirwaybillFinanceCreateResponse.php
+++ b/backend/src/Response/AirwaybillFinanceCreateResponse.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Response;
+
+class AirwaybillFinanceCreateResponse
+{
+    public $createdAt;
+
+}

--- a/backend/src/Response/ContainerFinanceCreateResponse.php
+++ b/backend/src/Response/ContainerFinanceCreateResponse.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Response;
+
+class ContainerFinanceCreateResponse
+{
+    public $createdAt;
+
+}

--- a/backend/src/Response/ShipmentFinanceCreateResponse.php
+++ b/backend/src/Response/ShipmentFinanceCreateResponse.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Response;
+
+class ShipmentFinanceCreateResponse
+{
+    public $createdAt;
+
+}

--- a/backend/src/Response/ShipmentFinanceGetResponse.php
+++ b/backend/src/Response/ShipmentFinanceGetResponse.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Request;
+
+class ShipmentFinanceGetResponse
+{
+    public $shipmentID;
+
+    public $trackNumber;
+
+    public $stageDescription;
+
+    public $stageCost;
+
+    public $shipmentStatus;
+
+    public $currency;
+
+    public $createdByUser;
+
+    public $createdByUserImage;
+
+    public $updatedByUser;
+
+    public $updatedByUserImage;
+
+}

--- a/backend/src/Response/WarehouseGetResponse.php
+++ b/backend/src/Response/WarehouseGetResponse.php
@@ -16,6 +16,8 @@ class WarehouseGetResponse
 
     public $location;
 
+    public $type;
+
     public $createdByUser;
 
     public $createdByUserImage;

--- a/backend/src/Service/AirwaybillFinanceService.php
+++ b/backend/src/Service/AirwaybillFinanceService.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Service;
+
+use App\AutoMapping;
+use App\Entity\AirwaybillFinanceEntity;
+use App\Manager\AirwaybillFinanceManager;
+use App\Request\AirwaybillFinanceCreateRequest;
+use App\Response\AirwaybillFinanceCreateResponse;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+class AirwaybillFinanceService
+{
+    private $autoMapping;
+    private $airwaybillFinanceManager;
+    private $params;
+
+    public function __construct(AutoMapping $autoMapping, AirwaybillFinanceManager $airwaybillFinanceManager, ParameterBagInterface $params)
+    {
+        $this->autoMapping = $autoMapping;
+        $this->airwaybillFinanceManager = $airwaybillFinanceManager;
+
+        $this->params = $params->get('upload_base_url') . '/';
+    }
+
+    public function create(AirwaybillFinanceCreateRequest $request)
+    {
+        $airwaybillEntityResult = $this->airwaybillFinanceManager->create($request);
+
+        return $this->autoMapping->map(AirwaybillFinanceEntity::class, AirwaybillFinanceCreateResponse::class, $airwaybillEntityResult);
+    }
+
+}

--- a/backend/src/Service/AirwaybillService.php
+++ b/backend/src/Service/AirwaybillService.php
@@ -6,6 +6,7 @@ use App\AutoMapping;
 use App\Entity\AirwaybillEntity;
 use App\Manager\AirwaybillManager;
 use App\Request\AirwaybillCreateRequest;
+use App\Request\AirwaybillStatusUpdateRequest;
 use App\Request\AirwaybillUpdateRequest;
 use App\Response\AirwaybillCreateResponse;
 use App\Response\AirwaybillGetResponse;
@@ -37,6 +38,13 @@ class AirwaybillService
     public function update(AirwaybillUpdateRequest $request)
     {
         $airwaybillResult = $this->airwaybillManager->update($request);
+
+        return $this->autoMapping->map(AirwaybillEntity::class, AirwaybillGetResponse::class, $airwaybillResult);
+    }
+
+    public function updateStatus(AirwaybillStatusUpdateRequest $request)
+    {
+        $airwaybillResult = $this->airwaybillManager->updateStatus($request);
 
         return $this->autoMapping->map(AirwaybillEntity::class, AirwaybillGetResponse::class, $airwaybillResult);
     }

--- a/backend/src/Service/ContainerFinanceService.php
+++ b/backend/src/Service/ContainerFinanceService.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Service;
+
+use App\AutoMapping;
+use App\Entity\ContainerFinanceEntity;
+use App\Manager\ContainerFinanceManager;
+use App\Request\ContainerFinanceCreateRequest;
+use App\Response\ContainerFinanceCreateResponse;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+class ContainerFinanceService
+{
+    private $autoMapping;
+    private $containerFinanceManager;
+    private $params;
+
+    public function __construct(AutoMapping $autoMapping, ContainerFinanceManager $containerFinanceManager, ParameterBagInterface $params)
+    {
+        $this->autoMapping = $autoMapping;
+        $this->containerFinanceManager = $containerFinanceManager;
+
+        $this->params = $params->get('upload_base_url') . '/';
+    }
+
+    public function create(ContainerFinanceCreateRequest $request)
+    {
+        $containerFinanceResult = $this->containerFinanceManager->create($request);
+
+        return $this->autoMapping->map(ContainerFinanceEntity::class, ContainerFinanceCreateResponse::class, $containerFinanceResult);
+    }
+
+}

--- a/backend/src/Service/ContainerService.php
+++ b/backend/src/Service/ContainerService.php
@@ -6,6 +6,7 @@ use App\AutoMapping;
 use App\Entity\ContainerEntity;
 use App\Manager\ContainerManager;
 use App\Request\ContainerCreateRequest;
+use App\Request\ContainerStatusUpdateRequest;
 use App\Request\ContainerUpdateRequest;
 use App\Response\ContainerCreateResponse;
 use App\Response\ContainerGetResponse;
@@ -37,6 +38,13 @@ class ContainerService
     public function update(ContainerUpdateRequest $request)
     {
         $containerResult = $this->containerManager->update($request);
+
+        return $this->autoMapping->map(ContainerEntity::class, ContainerGetResponse::class, $containerResult);
+    }
+
+    public function updateStatus(ContainerStatusUpdateRequest $request)
+    {
+        $containerResult = $this->containerManager->updateStatus($request);
 
         return $this->autoMapping->map(ContainerEntity::class, ContainerGetResponse::class, $containerResult);
     }

--- a/backend/src/Service/ShipmentFinanceService.php
+++ b/backend/src/Service/ShipmentFinanceService.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Service;
+
+use App\AutoMapping;
+use App\Entity\ShipmentFinanceEntity;
+use App\Manager\ShipmentFinanceManager;
+use App\Request\ShipmentFinanceCreateRequest;
+use App\Request\ShipmentFinanceGetResponse;
+use App\Response\ShipmentFinanceCreateResponse;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+class ShipmentFinanceService
+{
+    private $autoMapping;
+    private $shipmentFinanceManager;
+    private $params;
+
+    public function __construct(AutoMapping $autoMapping, ShipmentFinanceManager $shipmentFinanceManager, ParameterBagInterface $params)
+    {
+        $this->autoMapping = $autoMapping;
+        $this->shipmentFinanceManager = $shipmentFinanceManager;
+
+        $this->params = $params->get('upload_base_url') . '/';
+    }
+
+    public function create(ShipmentFinanceCreateRequest $request)
+    {
+        $shipmentFinanceResult = $this->shipmentFinanceManager->create($request);
+
+        return $this->autoMapping->map(ShipmentFinanceEntity::class, ShipmentFinanceCreateResponse::class, $shipmentFinanceResult);
+    }
+
+    public function getAllCostsByShipmentIdAndTrackNumber($shipmentID, $trackNumber)
+    {
+        $shipmentFinanceResponse = [];
+
+        $shipmentFinances = $this->shipmentFinanceManager->getAllCostsByShipmentIdAndTrackNumber($shipmentID, $trackNumber);
+        
+        foreach($shipmentFinances as $shipmentFinance)
+        {
+            if($shipmentFinance['createdByUserImage'])
+            {
+                $shipmentFinance['createdByUserImage'] = $this->params . $shipmentFinance['createdByUserImage'];
+            }
+
+            if($shipmentFinance['updatedByUserImage'])
+            {
+                $shipmentFinance['updatedByUserImage'] = $this->params . $shipmentFinance['updatedByUserImage'];
+            }
+
+            $shipmentFinanceResponse[] = $this->autoMapping->map('array', ShipmentFinanceGetResponse::class, $shipmentFinance);
+        }
+        
+        return $shipmentFinanceResponse;
+    }
+
+}


### PR DESCRIPTION
- Update container status separated from update the container info API.
- Update air waybill status separated from update the air waybill info API.
- "status" field removed from update travel info request because already there is an endpoint for update the status of a travel exclusively.